### PR TITLE
Idle timeout & delete message only on exception

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    osbourne (1.1.5)
+    osbourne (1.2)
       aws-sdk-core (>= 3.37, < 4)
       aws-sdk-sns (>= 1.5, < 2)
       aws-sdk-sqs (>= 1.6, < 2)

--- a/lib/osbourne/version.rb
+++ b/lib/osbourne/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Osbourne
-  VERSION = "1.1.5"
+  VERSION = "1.2"
 end

--- a/lib/osbourne/worker_base.rb
+++ b/lib/osbourne/worker_base.rb
@@ -79,6 +79,7 @@ module Osbourne
                         threads: Osbourne.threads_per_worker,
                         queue_name: default_queue_name,
                         dead_letter_queue: true,
+                        idle_timeout: 600,
                         max_retry_count: Osbourne.max_retry_count)
         self.config = {
           topic_names:     Array(topics),
@@ -87,7 +88,8 @@ module Osbourne
           max_wait:        max_wait,
           threads:         threads,
           dead_letter:     dead_letter_queue,
-          max_retry_count: max_retry_count
+          max_retry_count: max_retry_count,
+          idle_timeout:    idle_timeout
         }
       end
       # rubocop:enable Metrics/ParameterLists

--- a/spec/lib/osbourne/launcher_spec.rb
+++ b/spec/lib/osbourne/launcher_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 class TestWorker < Osbourne::WorkerBase
-  worker_config topics: %w[test_topic_1 test_topic_2]
+  worker_config topics: %w[test_topic_1 test_topic_2], max_wait: 10, max_batch_size: 1
 
   def process(_message)
     self.class.processed ||= 0


### PR DESCRIPTION
Adding idle timeout to deal with long-polling bug in underlying SDK.

Also only deletes messages if the worker throws an exception.